### PR TITLE
refactor: 普通聊天去除 ai 参数 MaxCompletionTokens，支持思考的模型思维链会占用 token 数，导致 A…

### DIFF
--- a/service/ai_chat.go
+++ b/service/ai_chat.go
@@ -43,7 +43,7 @@ func (s *AIChatService) Chat(robotCtx mcp.RobotContext, aiMessages []openai.Chat
 		Stream:   false,
 	}
 	if aiConfig.MaxCompletionTokens > 0 {
-		req.MaxCompletionTokens = aiConfig.MaxCompletionTokens
+		// req.MaxCompletionTokens = aiConfig.MaxCompletionTokens
 	}
 	return vars.MCPService.ChatWithMCPTools(robotCtx, client, req, 0)
 }


### PR DESCRIPTION
…I 无内容输出