### PR TITLE
feat: 客户端支持企业微信应用离线通知与测试推送

### DIFF
--- a/controller/system_settings.go
+++ b/controller/system_settings.go
@@ -39,3 +39,17 @@ func (s *SystemSettings) SaveSystemSettings(c *gin.Context) {
 	}
 	resp.ToResponse(nil)
 }
+func (s *SystemSettings) TestNotification(c *gin.Context) {
+	var req model.SystemSettings
+	resp := appx.NewResponse(c)
+	if ok, err := appx.BindAndValid(c, &req); !ok || err != nil {
+		resp.ToErrorResponse(errors.New("参数错误"))
+		return
+	}
+	err := service.NewSystemSettingService(c).TestNotification(&req)
+	if err != nil {
+		resp.ToErrorResponse(err)
+		return
+	}
+	resp.ToResponse(nil)
+}

--- a/dto/login.go
+++ b/dto/login.go
@@ -32,6 +32,34 @@ type PushPlusNotificationResponse struct {
 	Data string `json:"data"`
 }
 
+type WechatWorkAccessTokenResponse struct {
+	ErrCode     int    `json:"errcode"`
+	ErrMsg      string `json:"errmsg"`
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+type WechatWorkSendMessageRequest struct {
+	ToUser  string                `json:"touser"`
+	MsgType string                `json:"msgtype"`
+	AgentID int64                 `json:"agentid"`
+	Text    WechatWorkTextMessage `json:"text"`
+	Safe    int                   `json:"safe"`
+}
+
+type WechatWorkTextMessage struct {
+	Content string `json:"content"`
+}
+
+type WechatWorkSendMessageResponse struct {
+	ErrCode      int    `json:"errcode"`
+	ErrMsg       string `json:"errmsg"`
+	InvalidUser  string `json:"invaliduser"`
+	InvalidParty string `json:"invalidparty"`
+	InvalidTag   string `json:"invalidtag"`
+	ResponseCode string `json:"response_code"`
+}
+
 type SliderVerifyRequest struct {
 	Data62 string `form:"data62" json:"data62" binding:"required"`
 	Ticket string `form:"ticket" json:"ticket" binding:"required"`

--- a/model/system_settings.go
+++ b/model/system_settings.go
@@ -5,8 +5,9 @@ import "gorm.io/datatypes"
 type NotificationType string
 
 const (
-	NotificationTypePushPlus NotificationType = "push_plus"
-	NotificationTypeEmail    NotificationType = "email"
+	NotificationTypePushPlus      NotificationType = "push_plus"
+	NotificationTypeEmail         NotificationType = "email"
+	NotificationTypeWechatWorkApp NotificationType = "wechat_work_app"
 )
 
 type SystemSettings struct {
@@ -15,9 +16,14 @@ type SystemSettings struct {
 	WebhookHeaders             datatypes.JSONMap `gorm:"column:webhook_headers;type:json;comment:Webhook请求头(键值对)" json:"webhook_headers"`
 	APITokenEnabled            *bool             `gorm:"column:api_token_enabled;default:false;comment:启用API Token" json:"api_token_enabled"`
 	OfflineNotificationEnabled *bool             `gorm:"column:offline_notification_enabled;default:false;comment:启用离线通知" json:"offline_notification_enabled"`
-	NotificationType           NotificationType  `gorm:"column:notification_type;type:enum('push_plus','email');default:'push_plus';not null;comment:通知方式：push_plus-推送加，email-邮件" json:"notification_type"`
+	NotificationType           NotificationType  `gorm:"column:notification_type;type:enum('push_plus','email','wechat_work_app');default:'push_plus';not null;comment:通知方式：push_plus-推送加，email-邮件，wechat_work_app-企业微信应用" json:"notification_type"`
 	PushPlusURL                *string           `gorm:"column:push_plus_url;type:varchar(255);default:'';comment:Push Plus的URL" json:"push_plus_url"`
 	PushPlusToken              *string           `gorm:"column:push_plus_token;type:varchar(255);default:'';comment:Push Plus的Token" json:"push_plus_token"`
+	WechatWorkCorpID           *string           `gorm:"column:wechat_work_corp_id;type:varchar(255);default:'';comment:企业微信企业ID" json:"wechat_work_corp_id"`
+	WechatWorkAgentID          *string           `gorm:"column:wechat_work_agent_id;type:varchar(255);default:'';comment:企业微信应用AgentId" json:"wechat_work_agent_id"`
+	WechatWorkSecret           *string           `gorm:"column:wechat_work_secret;type:varchar(255);default:'';comment:企业微信应用Secret" json:"wechat_work_secret"`
+	WechatWorkProxyURL         *string           `gorm:"column:wechat_work_proxy_url;type:varchar(255);default:'';comment:企业微信代理地址" json:"wechat_work_proxy_url"`
+	WechatWorkToUser           *string           `gorm:"column:wechat_work_to_user;type:varchar(512);default:'';comment:企业微信推送用户ID，留空默认ALL" json:"wechat_work_to_user"`
 	AutoVerifyUser             *bool             `gorm:"column:auto_verify_user;default:false;comment:自动通过好友验证" json:"auto_verify_user"`
 	VerifyUserDelay            *int              `gorm:"column:verify_user_delay;default:60;comment:自动通过好友验证延迟时间(秒)" json:"verify_user_delay"`
 	AutoChatroomInvite         *bool             `gorm:"column:auto_chatroom_invite;default:false;comment:自动邀请进群" json:"auto_chatroom_invite"`

--- a/router/router.go
+++ b/router/router.go
@@ -138,6 +138,7 @@ func RegisterRouter(r *gin.Engine) error {
 	// 系统设置相关接口
 	api.GET("/robot/system-settings", systemSettingsCtl.GetSystemSettings)
 	api.POST("/robot/system-settings", systemSettingsCtl.SaveSystemSettings)
+	api.POST("/robot/system-settings/test-notification", systemSettingsCtl.TestNotification)
 
 	// OSS 设置相关接口
 	api.GET("/robot/oss-settings", ossSettingsCtl.GetOSSSettings)

--- a/service/login.go
+++ b/service/login.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 	"wechat-robot-client/dto"
 	"wechat-robot-client/model"
@@ -305,46 +307,150 @@ func (r *LoginService) LogoutCallback(req dto.LogoutNotificationRequest) (err er
 		return
 	}
 	if systemSettings.OfflineNotificationEnabled != nil && *systemSettings.OfflineNotificationEnabled {
-		// 发送离线通知
-		if systemSettings.NotificationType == model.NotificationTypePushPlus {
-			var result dto.PushPlusNotificationResponse
-			var title string
-			var content string
-			if req.Type == "offline" {
-				title = "机器人掉线通知"
-				content = fmt.Sprintf("您的机器人（%s）掉线啦~~~", vars.RobotRuntime.WxID)
-			} else {
-				title = "机器人发送心跳失败"
-				content = fmt.Sprintf("您的机器人（%s）第%d次发送心跳失败了~~~", vars.RobotRuntime.WxID, req.RetryCount)
-			}
-			httpResp, err1 := resty.New().R().
-				SetHeader("Content-Type", "application/json;chartset=utf-8").
-				SetBody(dto.PushPlusNotificationRequest{
-					Token:   *systemSettings.PushPlusToken,
-					Title:   title,
-					Content: content,
-					Channel: "wechat",
-				}).
-				SetResult(&result).
-				Post(*systemSettings.PushPlusURL)
-			if err1 != nil {
-				log.Printf("接收到掉线通知，发送离线通知失败: %v", err1)
-				return
-			}
-			if httpResp.StatusCode() != 200 {
-				log.Printf("接收到掉线通知，发送离线通知失败，HTTP状态码: %d", httpResp.StatusCode())
-				return
-			}
-			if result.Code != 200 {
-				log.Printf("接收到掉线通知，发送离线通知失败，PushPlus返回错误: %s", result.Msg)
-				return
-			}
-			log.Printf("接收到掉线通知，发送离线通知成功")
+		if notifyErr := r.sendOfflineNotification(systemSettings, req); notifyErr != nil {
+			log.Printf("接收到掉线通知，发送离线通知失败: %v", notifyErr)
+			return
 		}
+		log.Printf("接收到掉线通知，发送离线通知成功")
 		return
 	}
 
-	log.Printf("接收到掉线通知，系统设置未开启掉线通知")
-
+	log.Printf("接收到掉线通知，系统设置未开启离线通知")
 	return
+}
+
+func (r *LoginService) sendOfflineNotification(systemSettings *model.SystemSettings, req dto.LogoutNotificationRequest) error {
+	title, content := buildOfflineNotificationMessage(req)
+
+	switch systemSettings.NotificationType {
+	case model.NotificationTypePushPlus:
+		return r.sendPushPlusNotification(systemSettings, title, content)
+	case model.NotificationTypeWechatWorkApp:
+		return r.sendWechatWorkAppNotification(systemSettings, content)
+	case model.NotificationTypeEmail:
+		return errors.New("暂不支持邮件通知")
+	default:
+		return fmt.Errorf("不支持的通知类型: %s", systemSettings.NotificationType)
+	}
+}
+
+func (r *LoginService) sendPushPlusNotification(systemSettings *model.SystemSettings, title, content string) error {
+	pushPlusURL := getTrimmedString(systemSettings.PushPlusURL)
+	pushPlusToken := getTrimmedString(systemSettings.PushPlusToken)
+	if pushPlusURL == "" {
+		return errors.New("PushPlus 地址不能为空")
+	}
+	if pushPlusToken == "" {
+		return errors.New("PushPlus Token 不能为空")
+	}
+
+	var result dto.PushPlusNotificationResponse
+	httpResp, err := resty.New().R().
+		SetHeader("Content-Type", "application/json;chartset=utf-8").
+		SetBody(dto.PushPlusNotificationRequest{
+			Token:   pushPlusToken,
+			Title:   title,
+			Content: content,
+			Channel: "wechat",
+		}).
+		SetResult(&result).
+		Post(pushPlusURL)
+	if err != nil {
+		return err
+	}
+	if httpResp.StatusCode() != 200 {
+		return fmt.Errorf("PushPlus HTTP 状态码异常: %d", httpResp.StatusCode())
+	}
+	if result.Code != 200 {
+		return fmt.Errorf("PushPlus 返回错误: %s", result.Msg)
+	}
+	return nil
+}
+
+func (r *LoginService) sendWechatWorkAppNotification(systemSettings *model.SystemSettings, content string) error {
+	corpID := getTrimmedString(systemSettings.WechatWorkCorpID)
+	agentIDText := getTrimmedString(systemSettings.WechatWorkAgentID)
+	secret := getTrimmedString(systemSettings.WechatWorkSecret)
+	proxyURL := getTrimmedString(systemSettings.WechatWorkProxyURL)
+	toUser := getTrimmedString(systemSettings.WechatWorkToUser)
+
+	if corpID == "" {
+		return errors.New("企业微信企业ID不能为空")
+	}
+	if agentIDText == "" {
+		return errors.New("企业微信应用AgentId不能为空")
+	}
+	if secret == "" {
+		return errors.New("企业微信应用Secret不能为空")
+	}
+	if toUser == "" {
+		toUser = "ALL"
+	}
+
+	agentID, err := strconv.ParseInt(agentIDText, 10, 64)
+	if err != nil {
+		return fmt.Errorf("企业微信应用AgentId格式错误: %w", err)
+	}
+
+	client := resty.New()
+	if proxyURL != "" {
+		client.SetProxy(proxyURL)
+	}
+
+	var tokenResp dto.WechatWorkAccessTokenResponse
+	httpResp, err := client.R().
+		SetHeader("Content-Type", "application/json;chartset=utf-8").
+		SetQueryParam("corpid", corpID).
+		SetQueryParam("corpsecret", secret).
+		SetResult(&tokenResp).
+		Get("https://qyapi.weixin.qq.com/cgi-bin/gettoken")
+	if err != nil {
+		return fmt.Errorf("获取企业微信 access_token 失败: %w", err)
+	}
+	if httpResp.StatusCode() != 200 {
+		return fmt.Errorf("获取企业微信 access_token HTTP 状态码异常: %d", httpResp.StatusCode())
+	}
+	if tokenResp.ErrCode != 0 {
+		return fmt.Errorf("获取企业微信 access_token 失败: %s", tokenResp.ErrMsg)
+	}
+
+	var sendResp dto.WechatWorkSendMessageResponse
+	httpResp, err = client.R().
+		SetHeader("Content-Type", "application/json;chartset=utf-8").
+		SetQueryParam("access_token", tokenResp.AccessToken).
+		SetBody(dto.WechatWorkSendMessageRequest{
+			ToUser:  toUser,
+			MsgType: "text",
+			AgentID: agentID,
+			Text: dto.WechatWorkTextMessage{
+				Content: content,
+			},
+			Safe: 0,
+		}).
+		SetResult(&sendResp).
+		Post("https://qyapi.weixin.qq.com/cgi-bin/message/send")
+	if err != nil {
+		return fmt.Errorf("发送企业微信应用通知失败: %w", err)
+	}
+	if httpResp.StatusCode() != 200 {
+		return fmt.Errorf("发送企业微信应用通知 HTTP 状态码异常: %d", httpResp.StatusCode())
+	}
+	if sendResp.ErrCode != 0 {
+		return fmt.Errorf("发送企业微信应用通知失败: %s", sendResp.ErrMsg)
+	}
+	return nil
+}
+
+func buildOfflineNotificationMessage(req dto.LogoutNotificationRequest) (string, string) {
+	if req.Type == "offline" {
+		return "机器人掉线通知", fmt.Sprintf("您的机器人（%s）掉线啦~~~", vars.RobotRuntime.WxID)
+	}
+	return "机器人发送心跳失败", fmt.Sprintf("您的机器人（%s）第%d次发送心跳失败了~~~", vars.RobotRuntime.WxID, req.RetryCount)
+}
+
+func getTrimmedString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
 }

--- a/service/system_settings.go
+++ b/service/system_settings.go
@@ -58,6 +58,18 @@ func (s *SystemSettingService) SaveSystemSettings(req *model.SystemSettings) err
 	return nil
 }
 
+func (s *SystemSettingService) TestNotification(req *model.SystemSettings) error {
+	if req == nil {
+		return fmt.Errorf("测试通知参数不能为空")
+	}
+	if req.NotificationType != model.NotificationTypeWechatWorkApp {
+		return fmt.Errorf("当前仅支持测试企业微信应用通知")
+	}
+
+	content := "这是一条来自微信机器人管理后台的企业微信应用测试通知"
+	return NewLoginService(s.ctx).sendWechatWorkAppNotification(req, content)
+}
+
 func (s *SystemSettingService) updateWebhookConfig(req *model.SystemSettings) {
 	if req.WebhookURL != nil {
 		vars.Webhook.URL = *req.WebhookURL


### PR DESCRIPTION
## 变更说明
- 新增企业微信应用通知类型及相关配置字段
- 新增测试通知接口，支持直接测试企业微信应用推送
- 离线通知流程支持企业微信应用发送
- 修复本次改动范围内的中文乱码问题

## 验证
- 执行 `go test ./... -run TestNonExistent`

## 影响范围
- 客户端系统设置接口
- 离线通知发送逻辑
- 企业微信应用消息发送逻辑